### PR TITLE
don't force apt-get

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: ensure git
-  apt:
+  package:
     name: git
     state: present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,6 @@
   apt:
     name: git
     state: present
-    force_apt_get: yes
 
 - name: cloning pihole
   git:


### PR DESCRIPTION
this breaks on centos or other distributions that don't use apt