### PR TITLE
Support rev-server configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,12 +26,15 @@ pihole_setupvars_pihole_dns_2:
 pihole_setupvars_dns_fqdn_required: "true"
 pihole_setupvars_dns_bogus_priv: "true"
 pihole_setupvars_dnssec: "true"
+pihole_setupvars_dnsmasq_listening: "single"
 pihole_setupvars_conditional_forwarding: "false"
 pihole_setupvars_conditional_forwarding_ip:
 pihole_setupvars_conditional_forwarding_domain:
 pihole_setupvars_conditional_forwarding_reverse:
-pihole_setupvars_dnsmasq_listening: "single"
+pihole_setupvars_rev_server: "false"
+pihole_setupvars_rev_server_cidr:
+pihole_setupvars_rev_server_target:
+pihole_setupvars_rev_server_domain:
 pihole_setupvars_admin_email:
 pihole_setupvars_weblayout: "boxed"
 pihole_setupvars_webtheme: "default-dark"
-pihole_setupvars_rev_server: "false"

--- a/templates/setupVars.conf.j2
+++ b/templates/setupVars.conf.j2
@@ -2,11 +2,19 @@ WEBPASSWORD={{ pihole_setupvars_webpassword }}
 DNS_FQDN_REQUIRED={{ pihole_setupvars_dns_fqdn_required }}
 DNS_BOGUS_PRIV={{ pihole_setupvars_dns_bogus_priv }}
 DNSSEC={{ pihole_setupvars_dnssec }}
-CONDITIONAL_FORWARDING={{ pihole_setupvars_conditional_forwarding }}
 DNSMASQ_LISTENING={{ pihole_setupvars_dnsmasq_listening }}
+{% if pihole_setupvars_conditional_forwarding | bool %}
+CONDITIONAL_FORWARDING={{ pihole_setupvars_conditional_forwarding }}
 CONDITIONAL_FORWARDING_IP={{ pihole_setupvars_conditional_forwarding_ip }}
 CONDITIONAL_FORWARDING_DOMAIN={{ pihole_setupvars_conditional_forwarding_domain }}
 CONDITIONAL_FORWARDING_REVERSE={{ pihole_setupvars_conditional_forwarding_reverse }}
+{% endif %}
+{% if pihole_setupvars_rev_server | bool %}
+REV_SERVER={{ pihole_setupvars_rev_server }}
+REV_SERVER_CIDR={{ pihole_setupvars_rev_server_cidr }}
+REV_SERVER_TARGET={{ pihole_setupvars_rev_server_target }}
+REV_SERVER_DOMAIN={{ pihole_setupvars_rev_server_domain }}
+{% endif %}
 PIHOLE_INTERFACE={{ pihole_setupvars_pihole_interface }}
 IPV4_ADDRESS={{ pihole_setupvars_ipv4_address }}
 IPV6_ADDRESS={{ pihole_setupvars_ipv6_address }}
@@ -20,4 +28,3 @@ BLOCKING_ENABLED={{ pihole_setupvars_blocking_enabled }}
 ADMIN_EMAIL={{ pihole_setupvars_admin_email }}
 WEBUIBOXEDLAYOUT={{ pihole_setupvars_weblayout }}
 WEBTHEME={{ pihole_setupvars_webtheme }}
-REV_SERVER={{ pihole_setupvars_rev_server }}


### PR DESCRIPTION
The conditional forwarding options are legacy. They are replaced by the rev-server options.