### PR TITLE
Allow to use any number of DNS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ recommended to store this variable in ansible vault.
 #### pihole_setupvars_ipv4_address
 IPv4 adress of the pihole
 
-#### pihole_setupvars_pihole_dns_1/2
-DNS servers you want the pihole to use
+#### pihole_setupvars_pihole_dns
+List of DNS servers you want the pihole to use
 
 ##### DNS
 Alternative DNS Providers
@@ -62,8 +62,9 @@ Cloudflare: https://1.1.1.1/dns/
   vars:
     pihole_setupvars_ipv4_address: 192.168.1.100
     pihole_setupvars_webpassword: 35030714f1136486a612d7014b739a6c7ef3be589bb14b14a3d01f521dd7ef18
-    pihole_setupvars_pihole_dns_1: 1.1.1.1
-    pihole_setupvars_pihole_dns_2: 1.0.0.1
+    pihole_setupvars_pihole_dns:
+      - 1.1.1.1
+      - 1.0.0.1
   roles:
     - zfuller.pihole
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,8 +21,10 @@ pihole_setupvars_install_web_interface: "true"
 pihole_setupvars_lighttpd_enabled: "true"
 pihole_setupvars_webpassword:
 pihole_setupvars_blocking_enabled: "true"
-pihole_setupvars_pihole_dns_1: 8.8.8.8
-pihole_setupvars_pihole_dns_2:
+
+pihole_setupvars_pihole_dns:
+  - 8.8.8.8
+
 pihole_setupvars_dns_fqdn_required: "true"
 pihole_setupvars_dns_bogus_priv: "true"
 pihole_setupvars_dnssec: "true"

--- a/templates/setupVars.conf.j2
+++ b/templates/setupVars.conf.j2
@@ -18,8 +18,9 @@ REV_SERVER_DOMAIN={{ pihole_setupvars_rev_server_domain }}
 PIHOLE_INTERFACE={{ pihole_setupvars_pihole_interface }}
 IPV4_ADDRESS={{ pihole_setupvars_ipv4_address }}
 IPV6_ADDRESS={{ pihole_setupvars_ipv6_address }}
-PIHOLE_DNS_1={{ pihole_setupvars_pihole_dns_1 }}
-PIHOLE_DNS_2={{ pihole_setupvars_pihole_dns_2 }}
+{% for dns_entry in pihole_setupvars_pihole_dns %}
+PIHOLE_DNS_{{ loop.index }}={{ dns_entry }}
+{% endfor %}
 QUERY_LOGGING={{ pihole_setupvars_query_logging }}
 INSTALL_WEB_SERVER={{ pihole_setupvars_install_web_server }}
 INSTALL_WEB_INTERFACE={{ pihole_setupvars_install_web_interface }}


### PR DESCRIPTION
PiHole allows more than just the two currently configurable DNS servers. I therefore changed the config key to be a list and just iterate over it in the `setupVars` template using a Jinja2 for-loop with loop index.