### PR TITLE
Add Gravity Manegement

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ Cloudflare: https://1.1.1.1/dns/
   - 1.0.0.1
 ```
 
+## Managing Gravity lists:
+
+This role supports management of Gravity lists. For the role to insert and update these, the gravity management has to be enabled using
+
+```yaml
+pihole_gravity_managed: true
+```
+
+The Gravity items have to be provided as list with the items `address`, `comment` and optionally a `enabled` state:
+
+```yaml
+pihole_gravity_lists:
+    - address: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+      comment: Default Pi-Hole block list
+      enabled: true
+```
+
 ## Role Variables
 [defaults/main.yml](defaults/main.yml) for default values
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,10 @@ pihole_setupvars_rev_server_domain:
 pihole_setupvars_admin_email:
 pihole_setupvars_weblayout: "boxed"
 pihole_setupvars_webtheme: "default-dark"
+
+# Gravity database:
+pihole_gravity_managed: true
+pihole_gravity_lists:
+    - address: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+      comment: Default Pi-Hole block list
+      enabled: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+# handlers file
+---
+- name: restart pi-hole dns
+  command: "{{ pihole_bin_path }} restartdns"
+
+- name: update pi-hole gravity
+  command: "{{ pihole_bin_path }} -g"

--- a/tasks/gravity.yml
+++ b/tasks/gravity.yml
@@ -1,0 +1,10 @@
+---
+
+- name: add gravity lists
+  command:
+    argv:
+      - sqlite3
+      - "{{ pihole_etc_dir }}/gravity.db"
+      - "INSERT OR REPLACE INTO adlist (id, address, enabled, comment) VALUES ((SELECT id FROM adlist WHERE address = '{{ item.address }}'), '{{ item.address }}', {{ item.enabled | default(true) }}, '{{ item.comment }}');"
+  notify: update pi-hole gravity
+  with_items: "{{ pihole_gravity_lists }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,9 @@
     var: updatePihole.stdout_lines
   when: updatePihole.changed == true
 
+- include_tasks: gravity.yml
+  when: pihole_gravity_managed | bool
+
 - name: Finished! ipv4
   debug:
     msg: "visit http://{{ pihole_setupvars_ipv4_address }}/admin/ to start managing your pi-hole"


### PR DESCRIPTION
This PR adds a very first (crude) way of managing Gravity lists. Since v5.0 the lists are held and read from an SQLite3 database instead of a configuration file, so we need to interact with that database. Unfortunately Ansible doesn't provide a module for that, so we have to resort to calling commands.
